### PR TITLE
CI Pipeline for publishing releases with builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,11 +189,6 @@ jobs:
     #     name: scopes-windows
     #     path: scopes-windows.zip
 
-    - run: |
-
-        ls -al
-        ls -al scopes-linux
-        
     - name: Tag
       # NOTE: for some reason the latest versions cannot be used, so
       # we have to use this old one

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,37 +1,107 @@
 name: Scopes Nightly
 on:
+  push:
+    # DEBUG: for debugging run on branches too
+    # branches:
+    #   - main
+    #   - build-releases
+    # tags-ignore:
+    #   - 'v**-pre'
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * 0"
+#   schedule:
+#     - cron: "0 0 * * 0"
 jobs:
-  linux:
+
+  linux-build:
     runs-on: ubuntu-22.04
     outputs:
-      revision: ${{ steps.revision.outputs.scopes-revision }}
+      scopes-next-version: ${{ steps.version.outputs.scopes-next-version }}
+      scopes-build-version: ${{ steps.version.outputs.scopes-build-version }}
     steps:
-      - id: revision
-        run: |
-          echo "::set-output name=scopes-revision::$(hg identify https://hg.sr.ht/~duangle/scopes/)"
+
       - name: Install build dependencies
         run: sudo apt install mkdocs python3-pip libtinfo5
-      - name: Build
+      - name: Install MajorEO Package Manager
         run: |
-          curl https://hg.sr.ht/~duangle/majoreo/raw/eo | python3 - init majoreo && ./bin/eo import scopes
+
+          # install eo package manager
+          curl -S --no-progress-meter \
+              https://hg.sr.ht/~duangle/majoreo/raw/eo \
+                  | python3 - init majoreo
+
+      - name: Fetch Scopes Source Code and Build Recipes
+        run: |
+
+          # fetch the recipe
+          ./bin/eo import scopes
+          
+          # fetch the source code via the "source code" package
           ./bin/eo install -y scopes-source-unstable
-          # patch genie recipe
-          wget "https://raw.githubusercontent.com/ScopesCommunity/scopes-unstable/main/workarounds/genie.eo" -O ./external/recipes/genie.eo
-          ./build.sh
-          rm ./bin/eo
-          tar -czf scopes-unstable-linux-${{ steps.revision.outputs.scopes-revision }}.tar.gz bin/ doc/ include/ lib/ testing/ CREDITS.md LICENSE.md
+          
+          # patch genie recipe from the source code
+          curl -S --no-progress-meter \
+              "https://raw.githubusercontent.com/ScopesCommunity/scopes-unstable/main/workarounds/genie.eo" \
+              -o ./external/recipes/genie.eo
+
+      - name: Cache downloaded dependencies
+        id: cache-eo
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-eo-downloads
+        with:
+          path: ./.eo/dlcache
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('external/recipes/*.eo') }}
+              
+      - name: Install & Build Dependencies
+        run: |
+
+          ./bin/eo install -y genie clang clang-runtime spirv-tools spirv-cross pcre lmdb libffi
+          ./bin/eo sync
+
+      - name: Build Scopes
+        run: |
+
+          ./bin/genie gmake
+          make -j$(nproc) -C build config=release
+
+      # TODO: this shouldn't need the binary to get this info, it
+      # should be static in the code, its just challenging to parse
+      # config.h
+      - name: Get Version
+        id: version
+        env:
+          GH_RUN_NUMBER: ${{ github.run_number }}
+        run: |
+
+          ./bin/scopes -v
+
+          # get the version number, construct the build version and save to outputs
+          next_version="$(./bin/scopes -v | head -n 1 | awk '{print $2}')"
+          build_version="${next_version}-pre${GH_RUN_NUMBER}"
+
+          echo "Current in-source version number: ${next_version}"
+          echo "Build version: $build_version"
+          
+          echo "scopes-next-version=${next_version}" >> $GITHUB_OUTPUT
+          echo "scopes-build-version=" >> $GITHUB_OUTPUT
+
+      - name: Package artifact
+        run: |
+          
+          tar -czf \
+              scopes-linux.tar.gz \
+              bin/ doc/ include/ lib/ testing/ CREDITS.md LICENSE.md
+
       - name: Distribution Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: scopes-unstable-linux-${{ steps.revision.outputs.scopes-revision }}
-          path: scopes-unstable-linux-${{ steps.revision.outputs.scopes-revision }}.tar.gz
+          name: scopes-linux
+          path: scopes-linux.tar.gz
+
       - name: Standalone Documentation
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: scopes-unstable-docs-${{ steps.revision.outputs.scopes-revision }}
+          name: scopes-unstable-docs
           path: doc/
   windows:
     runs-on: windows-latest
@@ -41,22 +111,39 @@ jobs:
         shell: msys2 {0}
     if: ${{ !always() }}
     steps:
-      - uses: msys2/setup-msys2@v2
-      - name: Install build dependencies
-        run: pacman -S --noconfirm make mingw64/mingw-w64-x86_64-python mingw64/mingw-w64-x86_64-python-pip zip unzip mingw64/mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-libxml2
-      - name: Build
+
+      - id: revision
+        name: Resolve the current scopes revision
         run: |
-          wget "https://hg.sr.ht/~duangle/majoreo/raw/eo" -O ./eo
-          chmod +x ./eo
-          ./eo init
-          ./eo import scopes
-          ./eo install -y scopes-unstable
-      - name: Cleanup
-        run: |
-          rm -f ./bin/eo ./bin/genie.exe
-      - run: zip -r scopes-unstable-windows-${{ needs.linux.outputs.revision }}.zip bin/ doc/ include/ lib/ testing/ CREDITS.md LICENSE.md
-      - name: Distribution Artifact
-        uses: actions/upload-artifact@v3
+
+          rev=$(hg identify https://hg.sr.ht/~duangle/scopes/)
+          echo "scopes-revision=${rev}" >> $GITHUB_OUTPUT
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: scopes-unstable-windows-${{ needs.linux.outputs.revision }}
-          path: scopes-unstable-windows-${{ needs.linux.outputs.revision }}.zip
+          name: scopes-linux
+          path: scopes-${{ steps.revision.outputs.scopes-revision }}-linux.tar.gz
+      # DEBUG
+      # - name: Download Build Artifacts
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: scopes-windows
+      #     path: scopes-${{ steps.revision.outputs.scopes-revision }}-windows.zip
+          
+      - name: Tag
+        uses: fatjyc/github-tagger@v0.0.1
+        with:
+          tag: ${{ github.run_number }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          prerelease: true
+          name: ${{ steps.revision.outputs.scopes-build-version }}
+          tag_name: ${{ steps.revision.outputs.scopes-build-version }}
+          body: "Pre-release 'nightly' build of Scopes from upstream revision of: ${{ steps.revision.outputs.scopes-revision }}"
+          files: |
+            scopes-${{ steps.revision.outputs.scopes-revision }}-linux.tar.gz
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,5 +171,5 @@ jobs:
           Build number: ${{ steps.get-build-version.outputs.scopes-build-version }}
 
         files: |
-          scopes${{ steps.get-build-version.outputs.scopes-build-version }}-linux.tar.gz
+          scopes-linux.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,7 @@ jobs:
 
     - run: |
 
+        ls -al
         ls -al scopes-linux
         
     - name: Tag

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Cache downloaded dependencies
         id: cache-eo
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         env:
           cache-name: cache-eo-downloads
         with:
@@ -195,13 +195,13 @@ jobs:
         ls
         
     - name: Tag
-      uses: fatjyc/github-tagger@v0.0.1
+      uses: fatjyc/github-tagger@v0.0
       with:
         tag: ${{ steps.get-build-version.outputs.scopes-build-version }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Release
-      uses: softprops/action-gh-release@v0.1.15
+      uses: softprops/action-gh-release@v2
       with:
         prerelease: true
         name: |
@@ -214,7 +214,9 @@ jobs:
 
           Build number: ${{ steps.get-build-version.outputs.scopes-build-version }}
 
-        files: |
-          scopes-linux.tar.gz
+        fail_on_unmatched_files: true
+        with:
+            files: |
+              scopes-linux.tar.gz
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
         echo "scopes-revision=${rev}" >> $GITHUB_OUTPUT
 
     - name: Resolve build version
-      name: get-build-version
+      id: get-build-version
       env:
         GH_RUN_NUMBER: ${{ github.run_number }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,14 @@ jobs:
         run: |
 
           # install eo package manager
+          mkdir -p ./bin
           curl -S --no-progress-meter \
-              https://hg.sr.ht/~duangle/majoreo/raw/eo \
-                  | python3 - init majoreo
+              https://hg.sr.ht/~duangle/majoreo/raw/eo > ./bin/eo
+
+          chmod ug+x ./bin/eo
+
+          ./bin/eo init
+          
 
       - name: Fetch Scopes Source Code and Build Recipes
         run: |
@@ -103,14 +108,6 @@ jobs:
         with:
           name: scopes-unstable-docs
           path: doc/
-  windows-build:
-    runs-on: windows-latest
-    needs: linux-build
-    defaults:
-      run:
-        shell: msys2 {0}
-    if: ${{ !always() }}
-    steps:
 
       - id: revision
         name: Resolve the current scopes revision

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,9 +103,9 @@ jobs:
         with:
           name: scopes-unstable-docs
           path: doc/
-  windows:
+  windows-build:
     runs-on: windows-latest
-    needs: linux
+    needs: linux-build
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,17 +12,7 @@ on:
 #     - cron: "0 0 * * 0"
 jobs:
 
-  collect-metadata:
-    runs-on: ubuntu-22.04
-    outputs:
-      scopes-next-version: ${{ steps.version.outputs.scopes-next-version }}
-      scopes-build-version: ${{ steps.version.outputs.scopes-build-version }}
-
-    steps:
-
-
   linux-build:
-    needs: collect-metadata
     runs-on: ubuntu-22.04
     steps:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,18 @@ on:
 #     - cron: "0 0 * * 0"
 jobs:
 
-  linux-build:
+  collect-metadata:
     runs-on: ubuntu-22.04
     outputs:
       scopes-next-version: ${{ steps.version.outputs.scopes-next-version }}
       scopes-build-version: ${{ steps.version.outputs.scopes-build-version }}
+
+    steps:
+
+
+  linux-build:
+    needs: collect-metadata
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Install build dependencies
@@ -31,17 +38,17 @@ jobs:
 
           chmod ug+x ./bin/eo
 
-          ./bin/eo init
+          ./bin/eo init --silent-progress
           
 
       - name: Fetch Scopes Source Code and Build Recipes
         run: |
 
           # fetch the recipe
-          ./bin/eo import scopes
+          ./bin/eo import --silent-progress scopes
           
           # fetch the source code via the "source code" package
-          ./bin/eo install -y scopes-source-unstable
+          ./bin/eo install --silent-progress -y scopes-source-unstable
           
           # patch genie recipe from the source code
           curl -S --no-progress-meter \
@@ -60,8 +67,8 @@ jobs:
       - name: Install & Build Dependencies
         run: |
 
-          ./bin/eo install -y genie clang clang-runtime spirv-tools spirv-cross pcre lmdb libffi
-          ./bin/eo sync
+          ./bin/eo install --silent-progress -y genie clang clang-runtime spirv-tools spirv-cross pcre lmdb libffi
+          ./bin/eo sync --silent-progress
 
       - name: Build Scopes
         run: |
@@ -72,23 +79,23 @@ jobs:
       # TODO: this shouldn't need the binary to get this info, it
       # should be static in the code, its just challenging to parse
       # config.h
-      - name: Get Version
-        id: version
-        env:
-          GH_RUN_NUMBER: ${{ github.run_number }}
-        run: |
+      # - name: Get Version
+      #   id: version
+      #   env:
+      #     GH_RUN_NUMBER: ${{ github.run_number }}
+      #   run: |
 
-          ./bin/scopes -v
+      #     ./bin/scopes -v
 
-          # get the version number, construct the build version and save to outputs
-          next_version="$(./bin/scopes -v | head -n 1 | awk '{print $2}')"
-          build_version="${next_version}-pre${GH_RUN_NUMBER}"
+      #     # get the version number, construct the build version and save to outputs
+      #     next_version="$(./bin/scopes -v | head -n 1 | awk '{print $2}')"
+      #     build_version="${next_version}-pre${GH_RUN_NUMBER}"
 
-          echo "Current in-source version number: ${next_version}"
-          echo "Build version: $build_version"
+      #     echo "Current in-source version number: ${next_version}"
+      #     echo "Build version: $build_version"
           
-          echo "scopes-next-version=${next_version}" >> $GITHUB_OUTPUT
-          echo "scopes-build-version=" >> $GITHUB_OUTPUT
+      #     echo "scopes-next-version=${next_version}" >> $GITHUB_OUTPUT
+      #     echo "scopes-build-version=" >> $GITHUB_OUTPUT
 
       - name: Package artifact
         run: |
@@ -103,11 +110,12 @@ jobs:
           name: scopes-linux
           path: scopes-linux.tar.gz
 
-      - name: Standalone Documentation
-        uses: actions/upload-artifact@v4
-        with:
-          name: scopes-unstable-docs
-          path: doc/
+    release:
+      needs: linux-build
+      runs-on: ubuntu-22.04
+      
+      steps:
+
 
       - id: revision
         name: Resolve the current scopes revision
@@ -115,12 +123,42 @@ jobs:
 
           rev=$(hg identify https://hg.sr.ht/~duangle/scopes/)
           echo "scopes-revision=${rev}" >> $GITHUB_OUTPUT
+        
+      - name: Resolve build version
+        name: get-build-version
+        env:
+          GH_RUN_NUMBER: ${{ github.run_number }}
+        
+        run: |
+          curl -S --no-progress-meter https://hg.sr.ht/~duangle/scopes/raw/include/scopes/config.h > config.h
+
+          major=$(cat config.h | grep SCOPES_VERSION_MAJOR | awk '{print $3}')
+          minor=$(cat config.h | grep SCOPES_VERSION_MINOR | awk '{print $3}')
+          patch=$(cat config.h | grep SCOPES_VERSION_PATCH | awk '{print $3}')
+
+          next_version="${major}.${minor}.${patch}"
+
+          build_version="${next_version}-pre${GH_RUN_NUMBER}"
+
+          echo "Build version: ${build_version}"
+
+          echo "scopes-next-major-version=${major}" >> $GITHUB_OUTPUT
+          echo "scopes-next-minor-version=${minor}" >> $GITHUB_OUTPUT
+          echo "scopes-next-patch-version=${patch}" >> $GITHUB_OUTPUT
+          echo "scopes-next-version=${next_version}" >> $GITHUB_OUTPUT
+          echo "scopes-build-version=${build_version}" >> $GITHUB_OUTPUT
+        
+      - name: Standalone Documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: scopes-unstable-docs
+          path: doc/
 
       - name: Download Build Artifacts
         uses: actions/download-artifact@v4
         with:
           name: scopes-linux
-          path: scopes-${{ steps.revision.outputs.scopes-revision }}-linux.tar.gz
+          path: scopes-linux.tar.gz
       # DEBUG
       # - name: Download Build Artifacts
       #   uses: actions/download-artifact@v4
@@ -131,16 +169,23 @@ jobs:
       - name: Tag
         uses: fatjyc/github-tagger@v0.0.1
         with:
-          tag: ${{ github.run_number }}
+          tag: ${{ steps.get-build-version.outputs.scopes-build-version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Release
         uses: softprops/action-gh-release@v0.1.15
         with:
           prerelease: true
-          name: ${{ steps.revision.outputs.scopes-build-version }}
-          tag_name: ${{ steps.revision.outputs.scopes-build-version }}
-          body: "Pre-release 'nightly' build of Scopes from upstream revision of: ${{ steps.revision.outputs.scopes-revision }}"
+          name: |
+            Scopes Prerelease nightly build ${{ steps.revision.outputs.scopes-build-version }}
+          tag_name: ${{ steps.get-build-version.outputs.scopes-build-version }}
+          body: |
+            Pre-release "nightly" build of Scopes version: ${{ steps.get-build-version.outputs.scopes-next-version }}
+
+            Built from upstream commit revision: ${{ steps.revision.outputs.scopes-revision }}
+
+            Build number: ${{ steps.get-build-version.outputs.scopes-build-version }}
+
           files: |
-            scopes-${{ steps.revision.outputs.scopes-revision }}-linux.tar.gz
+            scopes${{ steps.get-build-version.outputs.scopes-build-version }}-linux.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,11 +111,14 @@ jobs:
         GH_RUN_NUMBER: ${{ github.run_number }}
 
       run: |
-        curl -S --no-progress-meter https://hg.sr.ht/~duangle/scopes/raw/include/scopes/config.h > config.h
 
-        major="$(cat config.h | grep SCOPES_VERSION_MAJOR | awk '{print $3}') | xargs"
-        minor="$(cat config.h | grep SCOPES_VERSION_MINOR | awk '{print $3}') | xargs"
-        patch="$(cat config.h | grep SCOPES_VERSION_PATCH | awk '{print $3}') | xargs"
+        # need to convert line endings
+        sudo apt install -y dos2unix        
+        curl -S --no-progress-meter https://hg.sr.ht/~duangle/scopes/raw/include/scopes/config.h | dos2unix > config.h
+
+        major="$(echo $(cat config.h | grep SCOPES_VERSION_MAJOR | awk '{print $3}'))"
+        minor="$(cat config.h | grep SCOPES_VERSION_MINOR | awk '{print $3}')"
+        patch="$(cat config.h | grep SCOPES_VERSION_PATCH | awk '{print $3}')"
 
         next_version="${major}.${minor}.${patch}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,7 @@ jobs:
         ls
         
     - name: Tag
-      uses: fatjyc/github-tagger@v0.0
+      uses: fatjyc/github-tagger@v0.0.3
       with:
         tag: ${{ steps.get-build-version.outputs.scopes-build-version }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,14 @@ on:
 #     - cron: "0 0 * * 0"
 jobs:
 
+  # TODO: before running builds or making releases check to see if
+  # there has been any changes by using cache invalidation
+
   linux-build:
     runs-on: ubuntu-22.04
     steps:
 
+      # TODO: can probably cache this on a timer to update every week or something
       - name: Install build dependencies
         run: sudo apt install mkdocs python3-pip libtinfo5
 
@@ -27,7 +31,7 @@ jobs:
           tar xvz -f scopes.tar.gz
 
         
-      - name: Install MajorEO Package
+      - name: Install MajorEO
         run: |
 
           cd scopes-default
@@ -81,11 +85,11 @@ jobs:
               scopes-linux.tar.gz \
               bin/ doc/ include/ lib/ testing/ CREDITS.md LICENSE.md
 
-      - name: Distribution Artifact
+      - name: Upload Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: scopes-linux
-          path: scopes-linux.tar.gz
+          path: scopes-default/scopes-linux.tar.gz
 
   release:
     needs: linux-build
@@ -109,9 +113,9 @@ jobs:
       run: |
         curl -S --no-progress-meter https://hg.sr.ht/~duangle/scopes/raw/include/scopes/config.h > config.h
 
-        major=$(cat config.h | grep SCOPES_VERSION_MAJOR | awk '{print $3}')
-        minor=$(cat config.h | grep SCOPES_VERSION_MINOR | awk '{print $3}')
-        patch=$(cat config.h | grep SCOPES_VERSION_PATCH | awk '{print $3}')
+        major="$(cat config.h | grep SCOPES_VERSION_MAJOR | awk '{print $3}') | xargs"
+        minor="$(cat config.h | grep SCOPES_VERSION_MINOR | awk '{print $3}') | xargs"
+        patch="$(cat config.h | grep SCOPES_VERSION_PATCH | awk '{print $3}') | xargs"
 
         next_version="${major}.${minor}.${patch}"
 
@@ -125,11 +129,11 @@ jobs:
         echo "scopes-next-version=${next_version}" >> $GITHUB_OUTPUT
         echo "scopes-build-version=${build_version}" >> $GITHUB_OUTPUT
 
-    - name: Standalone Documentation
-      uses: actions/upload-artifact@v4
-      with:
-        name: scopes-unstable-docs
-        path: doc/
+    # - name: Standalone Documentation
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: scopes-unstable-docs
+    #     path: doc/
 
     - name: Download Build Artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
 
           cd scopes-default
-          ./bin/eo install --silent-progress -y genie clang clang-runtime spirv-tools spirv-cross pcre lmdb libffi
+          ./bin/eo install --silent-progress -y genie clang spirv-tools spirv-cross pcre lmdb libffi
           ./bin/eo sync --silent-progress
 
       # TODO: we could cache the build of scopes as well if there were

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,8 +215,7 @@ jobs:
           Build number: ${{ steps.get-build-version.outputs.scopes-build-version }}
 
         fail_on_unmatched_files: true
-        with:
-            files: |
-              scopes-linux.tar.gz
+        files: |
+          scopes-linux.tar.gz
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,46 @@ jobs:
           name: scopes-linux
           path: scopes-default/scopes-linux.tar.gz
 
+  windows:
+    runs-on: windows-latest
+    # needs: linux
+    defaults:
+      run:
+        shell: msys2 {0}
+    if: ${{ !always() }}
+    steps:
+      - uses: msys2/setup-msys2@v2
+      - name: Install build dependencies
+        run: |
+          pacman -S --noconfirm \
+              make \
+              mingw64/mingw-w64-x86_64-python \
+              mingw64/mingw-w64-x86_64-python-pip \
+              zip \
+              unzip \
+              mingw64/mingw-w64-x86_64-gcc \
+              mingw64/mingw-w64-x86_64-libxml2
+
+      - name: Build
+        run: |
+          wget "https://hg.sr.ht/~duangle/majoreo/raw/eo" -O ./eo
+          chmod +x ./eo
+          ./eo init
+          ./eo import scopes
+          ./eo install -y scopes-unstable
+      - name: Cleanup
+        run: |
+          rm -f ./bin/eo ./bin/genie.exe
+      - run: |
+          zip -r scopes-unstable-windows-${{ needs.linux.outputs.revision }}.zip \
+              bin/ doc/ include/ lib/ testing/ CREDITS.md LICENSE.md
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: scopes-windows
+          path: scopes-unstable-windows-${{ needs.linux.outputs.revision }}.zip    
+          
   release:
     needs: linux-build
     runs-on: ubuntu-22.04
@@ -143,13 +183,17 @@ jobs:
       with:
         name: scopes-linux
         path: scopes-linux.tar.gz
-    # DEBUG
+
     # - name: Download Build Artifacts
     #   uses: actions/download-artifact@v4
     #   with:
     #     name: scopes-windows
-    #     path: scopes-${{ steps.revision.outputs.scopes-revision }}-windows.zip
+    #     path: scopes-windows.zip
 
+    - run: |
+
+        ls
+        
     - name: Tag
       uses: fatjyc/github-tagger@v0.0.1
       with:
@@ -172,4 +216,5 @@ jobs:
 
         files: |
           scopes-linux.tar.gz
+
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,6 @@ jobs:
 
           chmod ug+x ./bin/eo
 
-          ./bin/eo init --silent-progress
-
       - name: Patch recipes
         run: |
           cd scopes-default

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,8 @@ jobs:
 
     - run: |
 
-        ls
+        ls -al
+        file scopes-linux.tar.gz
         
     - name: Tag
       # NOTE: for some reason the latest versions cannot be used, so

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Scopes Nightly
 on:
   push:
     # DEBUG: for debugging run on branches too
-    # branches:
-    #   - main
-    #   - build-releases
+    branches:
+      - main
+      - build-releases
     # tags-ignore:
     #   - 'v**-pre'
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Install & Build Dependencies
         run: |
 
+          cd scopes-default
           ./bin/eo install --silent-progress -y genie clang clang-runtime spirv-tools spirv-cross pcre lmdb libffi
           ./bin/eo sync --silent-progress
 
@@ -68,12 +69,14 @@ jobs:
       - name: Build Scopes
         run: |
 
+          cd scopes-default
           ./bin/genie gmake
           make -j$(nproc) -C build config=release
 
       - name: Package artifact
         run: |
           
+          cd scopes-default
           tar -czf \
               scopes-linux.tar.gz \
               bin/ doc/ include/ lib/ testing/ CREDITS.md LICENSE.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,7 +195,9 @@ jobs:
         ls
         
     - name: Tag
-      uses: fatjyc/github-tagger@v0.0.3
+      # NOTE: for some reason the latest versions cannot be used, so
+      # we have to use this old one
+      uses: fatjyc/github-tagger@v0.0.1
       with:
         tag: ${{ steps.get-build-version.outputs.scopes-build-version }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,19 @@ jobs:
 
       - name: Install build dependencies
         run: sudo apt install mkdocs python3-pip libtinfo5
-      - name: Install MajorEO Package Manager
+
+      - name: Fetch Scopes Source Code and Build Recipes
         run: |
+
+          curl -S --no-progress-meter -o scopes.tar.gz https://hg.sr.ht/~duangle/scopes/archive/default.tar.gz
+          # extracts to "scopes-default" folder
+          tar xvz -f scopes.tar.gz
+
+        
+      - name: Install MajorEO Package
+        run: |
+
+          cd scopes-default
 
           # install eo package manager
           mkdir -p ./bin
@@ -29,21 +40,15 @@ jobs:
           chmod ug+x ./bin/eo
 
           ./bin/eo init --silent-progress
-          
 
-      - name: Fetch Scopes Source Code and Build Recipes
+      - name: Patch recipes
         run: |
-
-          # fetch the recipe
-          ./bin/eo import --silent-progress scopes
-          
-          # fetch the source code via the "source code" package
-          ./bin/eo install --silent-progress -y scopes-source-unstable
-          
+          cd scopes-default
           # patch genie recipe from the source code
           curl -S --no-progress-meter \
               "https://raw.githubusercontent.com/ScopesCommunity/scopes-unstable/main/workarounds/genie.eo" \
               -o ./external/recipes/genie.eo
+
 
       - name: Cache downloaded dependencies
         id: cache-eo
@@ -60,32 +65,13 @@ jobs:
           ./bin/eo install --silent-progress -y genie clang clang-runtime spirv-tools spirv-cross pcre lmdb libffi
           ./bin/eo sync --silent-progress
 
+      # TODO: we could cache the build of scopes as well if there were
+      # no changes
       - name: Build Scopes
         run: |
 
           ./bin/genie gmake
           make -j$(nproc) -C build config=release
-
-      # TODO: this shouldn't need the binary to get this info, it
-      # should be static in the code, its just challenging to parse
-      # config.h
-      # - name: Get Version
-      #   id: version
-      #   env:
-      #     GH_RUN_NUMBER: ${{ github.run_number }}
-      #   run: |
-
-      #     ./bin/scopes -v
-
-      #     # get the version number, construct the build version and save to outputs
-      #     next_version="$(./bin/scopes -v | head -n 1 | awk '{print $2}')"
-      #     build_version="${next_version}-pre${GH_RUN_NUMBER}"
-
-      #     echo "Current in-source version number: ${next_version}"
-      #     echo "Build version: $build_version"
-          
-      #     echo "scopes-next-version=${next_version}" >> $GITHUB_OUTPUT
-      #     echo "scopes-build-version=" >> $GITHUB_OUTPUT
 
       - name: Package artifact
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,82 +100,82 @@ jobs:
           name: scopes-linux
           path: scopes-linux.tar.gz
 
-    release:
-      needs: linux-build
-      runs-on: ubuntu-22.04
-      
-      steps:
+  release:
+    needs: linux-build
+    runs-on: ubuntu-22.04
+
+    steps:
 
 
-      - id: revision
-        name: Resolve the current scopes revision
-        run: |
+    - id: revision
+      name: Resolve the current scopes revision
+      run: |
 
-          rev=$(hg identify https://hg.sr.ht/~duangle/scopes/)
-          echo "scopes-revision=${rev}" >> $GITHUB_OUTPUT
-        
-      - name: Resolve build version
-        name: get-build-version
-        env:
-          GH_RUN_NUMBER: ${{ github.run_number }}
-        
-        run: |
-          curl -S --no-progress-meter https://hg.sr.ht/~duangle/scopes/raw/include/scopes/config.h > config.h
+        rev=$(hg identify https://hg.sr.ht/~duangle/scopes/)
+        echo "scopes-revision=${rev}" >> $GITHUB_OUTPUT
 
-          major=$(cat config.h | grep SCOPES_VERSION_MAJOR | awk '{print $3}')
-          minor=$(cat config.h | grep SCOPES_VERSION_MINOR | awk '{print $3}')
-          patch=$(cat config.h | grep SCOPES_VERSION_PATCH | awk '{print $3}')
+    - name: Resolve build version
+      name: get-build-version
+      env:
+        GH_RUN_NUMBER: ${{ github.run_number }}
 
-          next_version="${major}.${minor}.${patch}"
+      run: |
+        curl -S --no-progress-meter https://hg.sr.ht/~duangle/scopes/raw/include/scopes/config.h > config.h
 
-          build_version="${next_version}-pre${GH_RUN_NUMBER}"
+        major=$(cat config.h | grep SCOPES_VERSION_MAJOR | awk '{print $3}')
+        minor=$(cat config.h | grep SCOPES_VERSION_MINOR | awk '{print $3}')
+        patch=$(cat config.h | grep SCOPES_VERSION_PATCH | awk '{print $3}')
 
-          echo "Build version: ${build_version}"
+        next_version="${major}.${minor}.${patch}"
 
-          echo "scopes-next-major-version=${major}" >> $GITHUB_OUTPUT
-          echo "scopes-next-minor-version=${minor}" >> $GITHUB_OUTPUT
-          echo "scopes-next-patch-version=${patch}" >> $GITHUB_OUTPUT
-          echo "scopes-next-version=${next_version}" >> $GITHUB_OUTPUT
-          echo "scopes-build-version=${build_version}" >> $GITHUB_OUTPUT
-        
-      - name: Standalone Documentation
-        uses: actions/upload-artifact@v4
-        with:
-          name: scopes-unstable-docs
-          path: doc/
+        build_version="${next_version}-pre${GH_RUN_NUMBER}"
 
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: scopes-linux
-          path: scopes-linux.tar.gz
-      # DEBUG
-      # - name: Download Build Artifacts
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: scopes-windows
-      #     path: scopes-${{ steps.revision.outputs.scopes-revision }}-windows.zip
-          
-      - name: Tag
-        uses: fatjyc/github-tagger@v0.0.1
-        with:
-          tag: ${{ steps.get-build-version.outputs.scopes-build-version }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        echo "Build version: ${build_version}"
 
-      - name: Release
-        uses: softprops/action-gh-release@v0.1.15
-        with:
-          prerelease: true
-          name: |
-            Scopes Prerelease nightly build ${{ steps.revision.outputs.scopes-build-version }}
-          tag_name: ${{ steps.get-build-version.outputs.scopes-build-version }}
-          body: |
-            Pre-release "nightly" build of Scopes version: ${{ steps.get-build-version.outputs.scopes-next-version }}
+        echo "scopes-next-major-version=${major}" >> $GITHUB_OUTPUT
+        echo "scopes-next-minor-version=${minor}" >> $GITHUB_OUTPUT
+        echo "scopes-next-patch-version=${patch}" >> $GITHUB_OUTPUT
+        echo "scopes-next-version=${next_version}" >> $GITHUB_OUTPUT
+        echo "scopes-build-version=${build_version}" >> $GITHUB_OUTPUT
 
-            Built from upstream commit revision: ${{ steps.revision.outputs.scopes-revision }}
+    - name: Standalone Documentation
+      uses: actions/upload-artifact@v4
+      with:
+        name: scopes-unstable-docs
+        path: doc/
 
-            Build number: ${{ steps.get-build-version.outputs.scopes-build-version }}
+    - name: Download Build Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: scopes-linux
+        path: scopes-linux.tar.gz
+    # DEBUG
+    # - name: Download Build Artifacts
+    #   uses: actions/download-artifact@v4
+    #   with:
+    #     name: scopes-windows
+    #     path: scopes-${{ steps.revision.outputs.scopes-revision }}-windows.zip
 
-          files: |
-            scopes${{ steps.get-build-version.outputs.scopes-build-version }}-linux.tar.gz
+    - name: Tag
+      uses: fatjyc/github-tagger@v0.0.1
+      with:
+        tag: ${{ steps.get-build-version.outputs.scopes-build-version }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Release
+      uses: softprops/action-gh-release@v0.1.15
+      with:
+        prerelease: true
+        name: |
+          Scopes Prerelease nightly build ${{ steps.revision.outputs.scopes-build-version }}
+        tag_name: ${{ steps.get-build-version.outputs.scopes-build-version }}
+        body: |
+          Pre-release "nightly" build of Scopes version: ${{ steps.get-build-version.outputs.scopes-next-version }}
+
+          Built from upstream commit revision: ${{ steps.revision.outputs.scopes-revision }}
+
+          Build number: ${{ steps.get-build-version.outputs.scopes-build-version }}
+
+        files: |
+          scopes${{ steps.get-build-version.outputs.scopes-build-version }}-linux.tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,6 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: scopes-linux
-        path: scopes-linux.tar.gz
 
     # - name: Download Build Artifacts
     #   uses: actions/download-artifact@v4
@@ -192,8 +191,7 @@ jobs:
 
     - run: |
 
-        ls -al
-        file scopes-linux.tar.gz
+        ls -al scopes-linux
         
     - name: Tag
       # NOTE: for some reason the latest versions cannot be used, so


### PR DESCRIPTION
In addition to some refactoring I have implemented a pipeline that publishes Github releases with the build artifacts. This will create a standard URL for downloads rather than the CI artifact downloads.

Currently upstream Scopes has the next version in the source code `config.h`, so I pull this in, parse it, and create a prerelease version based on the pipeline number. Its not perfect and their could be something better but it will work.

TODOs include reintroducing windows builds and cleaning up some stuff, but I wanted to get feedback.
I would also like to try and get it to trigger via web hooks or something rather than a schedule as many spurious builds and releases will be made.